### PR TITLE
Add Portuguese infrastructure manager.

### DIFF
--- a/infrastructure-operators.csv
+++ b/infrastructure-operators.csv
@@ -65,3 +65,4 @@ DE,ZRB,ZossenRail Betriebsgesellschaft mbH
 FR,SNCF,SNCF Réseau
 IT,RhB,Rhätische Bahn AG
 LU,CFL,Société Nationale des Chemins de Fer Luxembourgeois
+PT,IP,"Infraestruturas de Portugal, S.A."


### PR DESCRIPTION
Enclosed in quote marks due to comma in name.