### PR TITLE
Update infrastructure-operators.csv

### DIFF
--- a/infrastructure-operators.csv
+++ b/infrastructure-operators.csv
@@ -65,3 +65,14 @@ DE,ZRB,ZossenRail Betriebsgesellschaft mbH
 FR,SNCF,SNCF Réseau
 IT,RhB,Rhätische Bahn AG
 LU,CFL,Société Nationale des Chemins de Fer Luxembourgeois
+UK,NR,Network Rail
+UK,HS1,High Speed 1
+UK,HS2,High Speed 2
+UK,TfL,Transport for London
+UK,TfWM,Transport for West Midlands
+UK,BTS,Blackpool Transport Services
+UK,TfGM,Transport for Greater Manchester
+UK,SPT,Strathclyde Partnership for Transport
+UK,ET,Edinburgh Trams
+UK,NET,Nottingham Express Transit
+UK,TWPTE,Tyne and Wear Passenger Transport Executive


### PR DESCRIPTION
added uk railway infrastructure owners - 
    NR,HS1,HS2 - mainline infrastructure
    TfL, TfWM, TfGM, BTS, SPT, ET, NET, TWPTE - metro/light rail infrastructure